### PR TITLE
Added alert message to create and destroy actions in the Admin's cont…

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -98,7 +98,7 @@ class Admin::AdminController < ApplicationController
       flash[:notice] = "#{thing} successfully created."
       redirect_to things_path(@route_name), notice: "#{thing.to_s.titleize} successfully created."
     else
-      render 'admin/new'
+      render 'admin/new', alert: "#{@controller_name.titleize} could not be updated. Please try again."
     end
   end
 
@@ -109,16 +109,19 @@ class Admin::AdminController < ApplicationController
     if @thing.update(thing_params)
       redirect_to things_path(@route_name), notice: "#{@controller_name.titleize} successfully updated."
     else
-      render 'admin/edit'
+      render 'admin/edit', alert: "#{@controller_name.titleize} could not be updated. Please try again."
     end
   end
 
   # DELETE /:things/:id
   def destroy
-    @thing.destroy
-
-    flash[:notice] = "#{thing} #{@thing.id} was successfully destroyed."
-    redirect_to action: :index
+    if @thing.destroy
+      flash[:notice] = "#{thing} #{@thing.id} was successfully destroyed."
+      redirect_to action: :index
+    else
+      flash[:alert] = "#{thing} #{@thing.id} could not be updated. Please try again."
+      redirect_to :back
+    end
   end
 
   private


### PR DESCRIPTION
…roller.

The reason why we need those messages is because we want to let the user know whether there was an error while trying to do something. We have validations on most input fields in forms, but not all of them display error messages (in case there's something missing, that was required). So it's a good to have the message up top as well. Correct anything if there's the need. 