### PR TITLE
Change iterator#all to return enum values as strings

### DIFF
--- a/lib/ceo/iterator.rb
+++ b/lib/ceo/iterator.rb
@@ -65,7 +65,6 @@ module CEO
         # TODO: Make all of this into a method.
         # map first-level values to a hash
         keys.each do |key|
-          # attr_object[self.class.acronymize(key)] = thing[key.to_s]
           attr_object[self.class.acronymize(key)] = thing.send(key.to_sym)
         end
 

--- a/lib/ceo/iterator.rb
+++ b/lib/ceo/iterator.rb
@@ -65,7 +65,8 @@ module CEO
         # TODO: Make all of this into a method.
         # map first-level values to a hash
         keys.each do |key|
-          attr_object[self.class.acronymize(key)] = thing[key.to_s]
+          # attr_object[self.class.acronymize(key)] = thing[key.to_s]
+          attr_object[self.class.acronymize(key)] = thing.send(key.to_sym)
         end
 
         # map nested values to a hash

--- a/test/ceo/iterator_test.rb
+++ b/test/ceo/iterator_test.rb
@@ -12,6 +12,10 @@ describe CEO::Iterator do
       name: 'Granny Smith',
       fruit_id: @fruit.id
     )
+    @banana = Banana.create(
+      name: 'Ripe Banana',
+      stage: 1
+    )
   end
 
   describe '#all' do
@@ -35,6 +39,17 @@ describe CEO::Iterator do
     it 'should return 20 records by default' do
       24.times { Apple.create }
       assert_equal 20, CEO::Iterator.new(Apple).all.count
+    end
+
+    it 'should return an enum attribute as a string' do
+      @iterator = CEO::Iterator.new(
+        Banana,
+        per_page: 10,
+        query: %w(stage)
+      )
+
+      stage = @iterator.all.first['Stage']
+      assert_equal @banana.stage, stage
     end
   end
 

--- a/test/ceo/iterator_test.rb
+++ b/test/ceo/iterator_test.rb
@@ -49,6 +49,8 @@ describe CEO::Iterator do
       )
 
       stage = @iterator.all.first['Stage']
+
+      assert_equal 'ripe', @banana.stage
       assert_equal @banana.stage, stage
     end
   end

--- a/test/dummy/app/models/banana.rb
+++ b/test/dummy/app/models/banana.rb
@@ -1,3 +1,6 @@
 class Banana < ActiveRecord::Base
   validates :name, presence: true
+
+  enum stage: [:green, :ripe, :brown, :trash]
 end
+

--- a/test/dummy/db/migrate/20151112204745_create_bananas.rb
+++ b/test/dummy/db/migrate/20151112204745_create_bananas.rb
@@ -2,6 +2,7 @@ class CreateBananas < ActiveRecord::Migration
   def change
     create_table :bananas do |t|
       t.string :name
+      t.integer :stage
 
       t.timestamps null: false
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20151112204745) do
 
   create_table "bananas", force: :cascade do |t|
     t.string   "name"
+    t.integer  "stage"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Instead of treating thing as a hash, treat it as an object, and thus return the expected results when calling key on thing, such as when key is an enum.

Fails with:

- Ruby 2.2.3 / Rails 4.0
- Ruby 2.2.2 / Rails 4.1
- Ruby 2.2.2 / Rails 4.2

TODO: Fix. :/
